### PR TITLE
fix: replaced yarn references by pnpm

### DIFF
--- a/docs/recipes/compound-fork-lending.md
+++ b/docs/recipes/compound-fork-lending.md
@@ -45,7 +45,7 @@ The `CompoundSupplyTokenHelper` helper class can be used to build a list of
 in an isolated market_ that reflect Compound's comptroller architecture.
 
 First, let's generate a new token fetcher with
-`yarn studio create-token-fetcher cozy-finance`. When prompted for a group,
+`pnpm studio create-token-fetcher cozy-finance`. When prompted for a group,
 select `Create New`, then enter `supply` as the ID and `Supply` as the label.
 When prompted for a network, select `ethereum`.
 

--- a/docs/recipes/curve-gauge-single-staking-farm.md
+++ b/docs/recipes/curve-gauge-single-staking-farm.md
@@ -26,7 +26,7 @@ specifically look at the `nGauge` implementation. This implementation is used
 for many newer Curve opportunities like the `rETH / ETH` pool.
 
 First, let's generate a new contract position fetcher with
-`yarn studio create-contract-position-fetcher curve`. When prompted for a group,
+`pnpm studio create-contract-position-fetcher curve`. When prompted for a group,
 select `Create New`, then enter `farm` as the ID and `Farms` as the label. When
 prompted for a network, select `ethereum`.
 

--- a/docs/recipes/master-chef-farm.md
+++ b/docs/recipes/master-chef-farm.md
@@ -30,7 +30,7 @@ These LP tokens can be staked in the Stargate `MasterChef` contract to earn
 `STG` rewards.
 
 First, let's generate a new contract position fetcher with
-`yarn studio create-contract-position-fetcher stargate`. When prompted for a
+`pnpm studio create-contract-position-fetcher stargate`. When prompted for a
 group, select `Create New`, then enter `farm` as the ID and `Farms` as the
 label. When prompted for a network, select `arbitrum`.
 

--- a/docs/recipes/synthetix-single-staking-farm.md
+++ b/docs/recipes/synthetix-single-staking-farm.md
@@ -24,7 +24,7 @@ stake their tokens in return for `SNX` rewards. Although the rewards for these
 farms are over, we will integrate these for educational purposes.
 
 First, let's generate a new contract position fetcher with
-`yarn studio create-contract-position-fetcher synthetix`. When prompted for a
+`pnpm studio create-contract-position-fetcher synthetix`. When prompted for a
 group, select `Create New`, then enter `farm` as the ID and `Farms` as the
 label. When prompted for a network, select `ethereum`.
 

--- a/docs/recipes/uniswap-v2-fork-pool-token.md
+++ b/docs/recipes/uniswap-v2-fork-pool-token.md
@@ -42,7 +42,7 @@ example, we'll look at **TraderJoe**, the largest DEX on the **Avalanche**
 network at the time of writing.
 
 First, let's generate a new token fetcher with
-`yarn studio create-token-fetcher trader-joe`. When prompted for a group, select
+`pnpm studio create-token-fetcher trader-joe`. When prompted for a group, select
 `Create New`, then enter `pool` as the ID and `Pools` as the label. When
 prompted for a network, select `avalanche`.
 

--- a/docs/recipes/vault-token.md
+++ b/docs/recipes/vault-token.md
@@ -23,7 +23,7 @@ a vault token that progressively gives the holder an increasing amount of `JOE`
 token over time.
 
 First, let's generate a new token fetcher with
-`yarn studio create-token-fetcher trader-joe`. When prompted for a group, select
+`pnpm studio create-token-fetcher trader-joe`. When prompted for a group, select
 `Create New`, then enter `x-joe` as the ID and `xJOE` as the label. When
 prompted for a network, select `avalanche`.
 

--- a/docs/tutorial/2-update-app-definition.md
+++ b/docs/tutorial/2-update-app-definition.md
@@ -109,7 +109,7 @@ Jar deposits are represented by an ERC20 token that _wraps_ the underlying token
 being deposited. Farms, however, are _not_ represented by a token.
 
 Our CLI allows us to quickly add groups to an existing app. Run
-`yarn studio create-group pickle`, and follow the prompts. For Jar tokens, we'll
+`pnpm studio create-group pickle`, and follow the prompts. For Jar tokens, we'll
 configure the ID to `jar`, the label to `Jars`, and the type to `token`. For
 farms, we'll configure the ID to `farm`, the label to `Farms`, and the type to
 `contract-position`.


### PR DESCRIPTION
Saw some references to `yarn`, replaced them with `pnpm`
