### PR TITLE
Update Axios POST signature

### DIFF
--- a/docs/apis/5-common-code-examples.md
+++ b/docs/apis/5-common-code-examples.md
@@ -22,6 +22,7 @@ async function getBalances() {
   try {
     const { data } = await Axios.post(
       `https://api.zapper.xyz/v2/balances/apps?addresses%5B%5D=${address}`,
+      undefined,
       {
         headers: {
           accept: "*/*",


### PR DESCRIPTION
## Description
I was getting HTTP 400 errors on the POST call, specifically got a `MISSING API KEY` symptomatic of a malformed request. 

The axios POST signature takes 3 params in, adding `undefined` at the `data` index of the function parameters fixed the issue. 

Note : might be related to an old node version ( <18 ), but could help dodge basic questions 

